### PR TITLE
Labelize newest pictures instead of the oldest

### DIFF
--- a/recognition/views.py
+++ b/recognition/views.py
@@ -19,7 +19,13 @@ def labelize_picture_left_sides(request):
             formset.save()
             return redirect('left_labelizer')
     else:
-        pics = Picture.objects.filter(left_label__isnull=True).order_by('-created_at')[0:50]
+        # Prefere pictures with right label but without left label
+        pics = Picture.objects.filter(left_label__isnull=True, right_label__isnull=False)
+        if not pics.exists():
+            # But no pictures are missing just the left label then fetch all unlabeled ones
+            pics = Picture.objects.filter(left_label__isnull=True)
+
+        pics = pics.order_by('-created_at')[0:50]
         formset = form_set(queryset=pics)
     return render(request, 'labelizer.html', {
         'labelizer_side': 'left',
@@ -39,7 +45,13 @@ def labelize_picture_right_sides(request):
             formset.save()
             return redirect('right_labelizer')
     else:
-        pics = Picture.objects.filter(right_label__isnull=True).order_by('-created_at')[0:50]
+        # Prefere pictures with right label but without left label
+        pics = Picture.objects.filter(right_label__isnull=True, left_label__isnull=False)
+        if not pics.exists():
+            # But no pictures are missing just the left label then fetch all unlabeled ones
+            pics = Picture.objects.filter(right_label__isnull=True)
+
+        pics = pics.order_by('-created_at')[0:50]
         formset = form_set(queryset=pics)
     return render(request, 'labelizer.html', {
         'labelizer_side': 'right',

--- a/recognition/views.py
+++ b/recognition/views.py
@@ -13,13 +13,13 @@ def labelize_picture_left_sides(request):
     Shows the HTML page for labelizing unlabeled left-sides of pictures.
     """
     form_set = modelformset_factory(Picture, form=PictureLeftLabelizerForm, extra=0)
-    pics = Picture.objects.filter(left_label__isnull=True).order_by('created_at')[0:50]
     if request.method == 'POST':
-        formset = form_set(request.POST, request.FILES, queryset=pics)
+        formset = form_set(request.POST, request.FILES)
         if formset.is_valid():
             formset.save()
             return redirect('left_labelizer')
     else:
+        pics = Picture.objects.filter(left_label__isnull=True).order_by('-created_at')[0:50]
         formset = form_set(queryset=pics)
     return render(request, 'labelizer.html', {
         'labelizer_side': 'left',
@@ -33,13 +33,13 @@ def labelize_picture_right_sides(request):
     Shows the HTML page for labelizing unlabeled right-sides of pictures.
     """
     form_set = modelformset_factory(Picture, form=PictureRightLabelizerForm, extra=0)
-    pics = Picture.objects.filter(right_label__isnull=True).order_by('created_at')[0:50]
     if request.method == 'POST':
-        formset = form_set(request.POST, request.FILES, queryset=pics)
+        formset = form_set(request.POST, request.FILES)
         if formset.is_valid():
             formset.save()
             return redirect('right_labelizer')
     else:
+        pics = Picture.objects.filter(right_label__isnull=True).order_by('-created_at')[0:50]
         formset = form_set(queryset=pics)
     return render(request, 'labelizer.html', {
         'labelizer_side': 'right',


### PR DESCRIPTION
Labelizer now shows most recent unlabeled pictures so we can label those and get fresh data

Labelizer now tries to prefer pictures with only one missing label over both labels missing. This means that when you label pictures for left side the labelizer first tries to find pictures that already have right side labeled but are missing label for the left side. 

Only if no such pictures are found the labelizer defaults to fetching the most recent unlabeled pictures.

This logic can and should be improved so the labelizer always shows up to 50 pictures but prefers the pictures with only one label. 